### PR TITLE
Add a variant of ImageMetadataWriter.WriteMetadata that works on file…

### DIFF
--- a/JpegXmpWritePluginMDE.Tests/ImageMetadataWriterTest.cs
+++ b/JpegXmpWritePluginMDE.Tests/ImageMetadataWriterTest.cs
@@ -45,5 +45,28 @@ namespace JpegXmpWritePluginMDE.Tests
 
 			Assert.True(actualResult.SequenceEqual(expectedResult));
 		}
-	}
+
+		[Fact]
+		public void TestWriteImageMetadataToFile()
+		{
+			// Set up a temporary file to write to 
+			string sourceFile = Path.Combine("Data", "xmpWriting_PictureWithMicrosoftXmp.jpg");
+			string expectedJpegFile = Path.Combine("Data", "xmpWriting_PictureWithMicrosoftXmpReencoded.jpg");
+			string expectedXmpFile = Path.Combine("Data", "xmpWriting_XmpContent.xmp");
+			string tempFile = Path.Combine("Data", $"{Guid.NewGuid()}");
+			File.Copy(sourceFile, tempFile);
+            
+			// Test the write with known data
+			IXmpMeta xmp = XmpMetaFactory.ParseFromString(File.ReadAllText(expectedXmpFile));
+			var metadata_objects = new object[] { xmp };
+			ImageMetadataWriter.WriteMetadata(tempFile, metadata_objects);
+
+			byte[] expectedResult = TestDataUtil.GetBytes(expectedJpegFile);
+			byte[] actualResult = TestDataUtil.GetBytes(tempFile);
+			File.Delete(tempFile);
+
+			// Check results are as expected
+			Assert.Equal(expectedResult, actualResult);
+		}
+    }
 }

--- a/JpegXmpWritePluginMDE/MetadataExtractor/ImageMetadataWriter.cs
+++ b/JpegXmpWritePluginMDE/MetadataExtractor/ImageMetadataWriter.cs
@@ -96,5 +96,24 @@ namespace JpegXmpWritePluginMDE.MetadataExtractor
 
 			throw new ImageProcessingException("File format is not supported");
 		}
-	}
+
+        /// <summary>Writes metadata to a file.</summary>
+        /// <param name="fileName">The path to a file to update.</param>
+        /// <param name="metadata">Collection of metadata objects.</param>
+        /// <exception cref="ImageProcessingException">The file type is unknown, or processing errors occurred.</exception>
+        public static void WriteMetadata(string fileName, IEnumerable<object> metadata)
+        {
+            ArgumentNullException.ThrowIfNull(fileName, nameof(fileName));
+
+            using var fileStream = File.Open(fileName, FileMode.Open, FileAccess.ReadWrite);
+            using var updatedData = WriteMetadata(fileStream, metadata);
+
+            // Write back to the source file on success
+            // Assumes that WriteMetadata either works or throws...
+            fileStream.Seek(0, SeekOrigin.Begin);
+            updatedData.Seek(0, SeekOrigin.Begin);
+            fileStream.SetLength(0);
+            updatedData.CopyTo(fileStream);
+        }
+    }
 }


### PR DESCRIPTION
…s, to gide all the details of the temporary streams it uses.

refs %comments over in DevOps%