### PR TITLE
Write the result of updating metadata to original stream

### DIFF
--- a/JpegXmpWritePluginMDE.Tests/Formats/Jpeg/JpegMetadataWriterTest.cs
+++ b/JpegXmpWritePluginMDE.Tests/Formats/Jpeg/JpegMetadataWriterTest.cs
@@ -21,6 +21,7 @@
 //    https://drewnoakes.com/code/exif/
 //
 #endregion
+using JpegXmpWritePluginMDE.MetadataExtractor;
 using JpegXmpWritePluginMDE.MetadataExtractor.Formats.Jpeg;
 using MetadataExtractor.Formats.Jpeg;
 using MetadataExtractor.IO;
@@ -93,14 +94,16 @@ namespace JpegXmpWritePluginMDE.Tests.Formats.Jpeg
 		[Fact]
 		public void TestWriteJpegMetadata()
 		{
-			var originalStream = TestDataUtil.OpenRead("Data/xmpWriting_PictureWithMicrosoftXmp.jpg");
-			IXmpMeta xmp = XmpMetaFactory.ParseFromString(File.ReadAllText("Data/xmpWriting_XmpContent.xmp"));
-			byte[] expectedResult = TestDataUtil.GetBytes("Data/xmpWriting_PictureWithMicrosoftXmpReencoded.jpg");
+			string writeToFile = TestDataUtil.GetFullTestFilePath("xmpWriting_PictureWithMicrosoftXmp.jpg");
+			string xmpToWrite = TestDataUtil.GetFullTestFilePath("xmpWriting_XmpContent.xmp");
+			string expectedOutputFile = TestDataUtil.GetFullTestFilePath("xmpWriting_PictureWithMicrosoftXmpReencoded.jpg");
+
+			IXmpMeta xmp = XmpMetaFactory.ParseFromString(File.ReadAllText(xmpToWrite));
+			byte[] expectedResult = TestDataUtil.GetBytes(expectedOutputFile);
 
 			var metadata_objects = new object[] { xmp };
-			var updatedStream = JpegMetadataWriter.WriteMetadata(originalStream, metadata_objects);
-
-			var actualResult = updatedStream.ToArray();
+			ImageMetadataWriter.WriteMetadata(writeToFile, metadata_objects);
+			byte[] actualResult = TestDataUtil.GetBytes(writeToFile);
 
 			Assert.True(actualResult.SequenceEqual(expectedResult));
 		}

--- a/JpegXmpWritePluginMDE.Tests/ImageMetadataWriterTest.cs
+++ b/JpegXmpWritePluginMDE.Tests/ImageMetadataWriterTest.cs
@@ -34,14 +34,18 @@ namespace JpegXmpWritePluginMDE.Tests
 		[Fact]
 		public void TestWriteImageMetadata()
 		{
-			var originalStream = TestDataUtil.OpenRead("Data/xmpWriting_PictureWithMicrosoftXmp.jpg");
-			IXmpMeta xmp = XmpMetaFactory.ParseFromString(File.ReadAllText("Data/xmpWriting_XmpContent.xmp"));
-			byte[] expectedResult = TestDataUtil.GetBytes("Data/xmpWriting_PictureWithMicrosoftXmpReencoded.jpg");
+			string writeToFile = TestDataUtil.CreateTestCopy("xmpWriting_PictureWithMicrosoftXmp.jpg");
+			string xmpToWrite = TestDataUtil.GetFullTestFilePath("xmpWriting_XmpContent.xmp");
+			string expectedOutputFile = TestDataUtil.GetFullTestFilePath("xmpWriting_PictureWithMicrosoftXmpReencoded.jpg");
+
+			IXmpMeta xmp = XmpMetaFactory.ParseFromString(File.ReadAllText(xmpToWrite));
+			byte[] expectedResult = TestDataUtil.GetBytes(expectedOutputFile);
 			
 			var metadata_objects = new object[] { xmp };
-			var updatedStream = ImageMetadataWriter.WriteMetadata(originalStream, metadata_objects);
+			ImageMetadataWriter.WriteMetadata(writeToFile, metadata_objects);
+			byte[] actualResult = TestDataUtil.GetBytes(writeToFile);
 
-			var actualResult = updatedStream.ToArray();
+			TestDataUtil.DeleteTestFile(writeToFile);
 
 			Assert.True(actualResult.SequenceEqual(expectedResult));
 		}

--- a/JpegXmpWritePluginMDE.Tests/TestDataUtil.cs
+++ b/JpegXmpWritePluginMDE.Tests/TestDataUtil.cs
@@ -1,5 +1,7 @@
 // Copyright (c) Drew Noakes and contributors. All Rights Reserved. Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
+using System.Reflection;
+
 namespace JpegXmpWritePluginMDE.Tests
 {
 	/// <summary>Utility functions for working with unit tests data files.</summary>
@@ -15,5 +17,43 @@ namespace JpegXmpWritePluginMDE.Tests
 		public static Stream OpenRead(string filePath) => new FileStream(GetPath(filePath), FileMode.Open, FileAccess.Read, FileShare.Read);
 
 		public static byte[] GetBytes(string filePath) => File.ReadAllBytes(GetPath(filePath));
+		/// <summary>
+		/// Gets path of the executing assembly
+		/// </summary>
+		/// <returns></returns>
+		public static string GetTestExecutionPath() => Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+		/// <summary>
+		/// Gets the path to the test file
+		/// </summary>
+		/// <param name="fileName"></param>
+		/// <returns></returns>
+		public static string GetFullTestFilePath(string fileName)
+		{
+			return Path.Combine(GetTestExecutionPath(), "Data", fileName);
+		}
+		/// <summary>
+		/// Creates copy of a test file to avoid multiple unit tests accessing the same file for writing
+		/// </summary>
+		/// <param name="fileName"></param>
+		/// <returns></returns>
+		public static string CreateTestCopy(string fileName)
+		{
+			string destinationFilePath = GetTestExecutionPath() + "\\" + "Data\\"+ fileName + Guid.NewGuid().ToString();
+			string originalFilePath = GetFullTestFilePath(fileName);
+			File.Copy(originalFilePath, destinationFilePath);
+			return destinationFilePath;
+		}
+		/// <summary>
+		/// Delete the test file
+		/// </summary>
+		/// <param name="fileName"></param>
+		public static void DeleteTestFile (string fileName)
+		{
+			if (File.Exists(fileName))
+			{
+				File.Delete(fileName);
+			}
+
+		}
 	}
 }

--- a/JpegXmpWritePluginMDE/MetadataExtractor/Formats/Jpeg/JpegFragmentWriter.cs
+++ b/JpegXmpWritePluginMDE/MetadataExtractor/Formats/Jpeg/JpegFragmentWriter.cs
@@ -144,20 +144,21 @@ namespace JpegXmpWritePluginMDE.MetadataExtractor.Formats.Jpeg
 		}
 
 		/// <summary>
-		/// Concatenates the provided JpegFragments into a <see cref="MemoryStream"/> object.
+		/// Concatenates the provided JpegFragments into a <see cref="byte[]"/>.
 		/// </summary>
 		/// <param name="fragments">a list of JpegFragments that shall be joined.</param>
 		[NotNull]
-		public static MemoryStream JoinFragments([NotNull] IEnumerable<JpegFragment> fragments)
+		public static byte[] JoinFragments([NotNull] IEnumerable<JpegFragment> fragments)
 		{
-			MemoryStream output = new MemoryStream();
-
-			foreach (JpegFragment fragment in fragments)
+			using (MemoryStream output = new MemoryStream())
 			{
-				output.Write(fragment.Bytes, 0, fragment.Bytes.Length);
-			}
+				foreach (JpegFragment fragment in fragments)
+				{
+					output.Write(fragment.Bytes, 0, fragment.Bytes.Length);
+				}
 
-			return output;
+				return output.ToArray();
+			}	
 		}
 
 		/// <summary>

--- a/JpegXmpWritePluginMDE/MetadataExtractor/ImageMetadataWriter.cs
+++ b/JpegXmpWritePluginMDE/MetadataExtractor/ImageMetadataWriter.cs
@@ -61,40 +61,51 @@ namespace JpegXmpWritePluginMDE.MetadataExtractor
 		/// <exception cref="ImageProcessingException">The file type is unknown, or processing errors occurred.</exception>
 		/// <exception cref="IOException"/>
 		[NotNull]
-		public static MemoryStream WriteMetadata([NotNull] Stream stream, IEnumerable<object> metadata)
+		public static void WriteMetadata([NotNull] string filePath, IEnumerable<object> metadata)
 		{
-			var fileType = FileTypeDetector.DetectFileType(stream);
-			switch (fileType)
+			using (var stream = new FileStream(filePath, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite))
 			{
-				case FileType.Jpeg: return JpegMetadataWriter.WriteMetadata(stream, metadata);
-					//case FileType.Tiff:
-					//case FileType.Arw:
-					//case FileType.Cr2:
-					//case FileType.Nef:
-					//case FileType.Orf:
-					//case FileType.Rw2:
-					//    return TiffMetadataReader.ReadMetadata(stream);
-					//case FileType.Psd:
-					//    return PsdMetadataReader.ReadMetadata(stream);
-					//case FileType.Png:
-					//    return PngMetadataReader.ReadMetadata(stream);
-					//case FileType.Bmp:
-					//    return new[] { BmpMetadataReader.ReadMetadata(stream) };
-					//case FileType.Gif:
-					//    return new[] { GifMetadataReader.ReadMetadata(stream) };
-					//case FileType.Ico:
-					//    return IcoMetadataReader.ReadMetadata(stream);
-					//case FileType.Pcx:
-					//    return new[] { PcxMetadataReader.ReadMetadata(stream) };
-					//case FileType.Riff:
-					//    return WebPMetadataReader.ReadMetadata(stream);
-					//case FileType.Raf:
-					//    return RafMetadataReader.ReadMetadata(stream);
-					//case FileType.QuickTime:
-					//    return QuicktimeMetadataReader.ReadMetadata(stream);
-			}
+				var fileType = FileTypeDetector.DetectFileType(stream);
+				try
+				{
+					switch (fileType)
+					{
+						case FileType.Jpeg:
+							JpegMetadataWriter.WriteMetadata(stream, metadata);
+							break;
+							//case FileType.Tiff:
+							//case FileType.Arw:
+							//case FileType.Cr2:
+							//case FileType.Nef:
+							//case FileType.Orf:
+							//case FileType.Rw2:
+							//    return TiffMetadataReader.ReadMetadata(stream);
+							//case FileType.Psd:
+							//    return PsdMetadataReader.ReadMetadata(stream);
+							//case FileType.Png:
+							//    return PngMetadataReader.ReadMetadata(stream);
+							//case FileType.Bmp:
+							//    return new[] { BmpMetadataReader.ReadMetadata(stream) };
+							//case FileType.Gif:
+							//    return new[] { GifMetadataReader.ReadMetadata(stream) };
+							//case FileType.Ico:
+							//    return IcoMetadataReader.ReadMetadata(stream);
+							//case FileType.Pcx:
+							//    return new[] { PcxMetadataReader.ReadMetadata(stream) };
+							//case FileType.Riff:
+							//    return WebPMetadataReader.ReadMetadata(stream);
+							//case FileType.Raf:
+							//    return RafMetadataReader.ReadMetadata(stream);
+							//case FileType.QuickTime:
+							//    return QuicktimeMetadataReader.ReadMetadata(stream);
+					}
+				}
+				catch (Exception)
+				{
 
-			throw new ImageProcessingException("File format is not supported");
+					throw new ImageProcessingException("File format is not supported");
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
* Instead of returning a MemoryStream, JpegMetadataWriter.WriteMetadata is void
* WriteMetadata compiles the jpeg fragments as before but writes the output (including XMP fragment) to original stream
* ImageMetadataWriter.WriteMetadata expects a filePath instead of a stream