### PR TITLE
Make TestWriteJpegMetadata create temp file to write, rather than upd…

### DIFF
--- a/JpegXmpWritePluginMDE.Tests/Formats/Jpeg/JpegMetadataWriterTest.cs
+++ b/JpegXmpWritePluginMDE.Tests/Formats/Jpeg/JpegMetadataWriterTest.cs
@@ -94,7 +94,7 @@ namespace JpegXmpWritePluginMDE.Tests.Formats.Jpeg
 		[Fact]
 		public void TestWriteJpegMetadata()
 		{
-			string writeToFile = TestDataUtil.GetFullTestFilePath("xmpWriting_PictureWithMicrosoftXmp.jpg");
+			string writeToFile = TestDataUtil.CreateTestCopy("xmpWriting_PictureWithMicrosoftXmp.jpg");
 			string xmpToWrite = TestDataUtil.GetFullTestFilePath("xmpWriting_XmpContent.xmp");
 			string expectedOutputFile = TestDataUtil.GetFullTestFilePath("xmpWriting_PictureWithMicrosoftXmpReencoded.jpg");
 
@@ -105,6 +105,7 @@ namespace JpegXmpWritePluginMDE.Tests.Formats.Jpeg
 			ImageMetadataWriter.WriteMetadata(writeToFile, metadata_objects);
 			byte[] actualResult = TestDataUtil.GetBytes(writeToFile);
 
+			TestDataUtil.DeleteTestFile(writeToFile);
 			Assert.True(actualResult.SequenceEqual(expectedResult));
 		}
 	}


### PR DESCRIPTION
…ating the original file

The nullability PR had a test failure due to multiple tests accessing xmpWriting_PictureWithMicrosoftXmp.jpg at the same time, and this is just a guess at what might cause if (this test writing the file, when something else is reading it)