### PR TITLE
Remove the hard coded RepositoryUrl and leave it up to SourceLink to …

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,11 +5,8 @@
 	<PropertyGroup>
 		<Authors>Michael Osthege;Ahsan Cheema</Authors>
 		<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-		<RepositoryType>git</RepositoryType>
-		<RepositoryUrl>https://github.com/ahsanaman92/JpegXmpWritePluginMDE.git</RepositoryUrl>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
-				<EmbedUntrackedSources>true</EmbedUntrackedSources>
-		<PublishRepositoryUrl>true</PublishRepositoryUrl>
+		<EmbedUntrackedSources>true</EmbedUntrackedSources>
 	</PropertyGroup>
 
 	<!-- common build properties -->

--- a/JpegXmpWritePluginMDE.sln
+++ b/JpegXmpWritePluginMDE.sln
@@ -10,6 +10,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{5BEB7B0C-940F-4CBE-BEF9-02C2C82A984F}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
+		Directory.Build.props = Directory.Build.props
 	EndProjectSection
 EndProject
 Global


### PR DESCRIPTION
…determine the value

Mainly because it makes it simpler to do a build out of https://github.com/BoldonJames/JpegXmpWritePluginMDE and get the correct URL, but it also means that local builds from test branches get the right value, e.g.

![image](https://github.com/ahsanaman92/JpegXmpWritePluginMDE/assets/1178570/b6e220ec-83e0-4c11-bce4-fea604969f42)
