### PR TITLE
Update Github actions to v5

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,9 +17,9 @@ jobs:
       DOTNET_NOLOGO: true
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 8.0.x
     - name: Restore dependencies

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -7,7 +7,7 @@ jobs:
  windows:
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Get version from release
       id: get_version
       run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: windows-latest
     if: "!github.event.release.prerelease"
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Get version from release
       id: get_version
       run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Because the v4 actions use deprecated stuff:

<img width="2155" height="138" alt="image" src="https://github.com/user-attachments/assets/21bcf468-902c-43b0-9323-303195b98a64" />
