### PR TITLE
Add a variant of WriteMetadata() which writes to streams

### DIFF
--- a/JpegXmpWritePluginMDE.Tests/ImageMetadataWriterTest.cs
+++ b/JpegXmpWritePluginMDE.Tests/ImageMetadataWriterTest.cs
@@ -49,5 +49,29 @@ namespace JpegXmpWritePluginMDE.Tests
 
 			Assert.True(actualResult.SequenceEqual(expectedResult));
 		}
+
+		[Fact]
+		public void TestWriteImageMetadataWithStream()
+		{
+			string writeToFile = TestDataUtil.CreateTestCopy("xmpWriting_PictureWithMicrosoftXmp.jpg");
+			string xmpToWrite = TestDataUtil.GetFullTestFilePath("xmpWriting_XmpContent.xmp");
+			string expectedOutputFile = TestDataUtil.GetFullTestFilePath("xmpWriting_PictureWithMicrosoftXmpReencoded.jpg");
+
+			IXmpMeta xmp = XmpMetaFactory.ParseFromString(File.ReadAllText(xmpToWrite));
+			byte[] expectedResult = TestDataUtil.GetBytes(expectedOutputFile);
+			
+			var metadata_objects = new object[] { xmp };
+
+			using (var stream = new FileStream(writeToFile, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite))
+			{
+				ImageMetadataWriter.WriteMetadata(stream, metadata_objects);
+			}
+			
+			byte[] actualResult = TestDataUtil.GetBytes(writeToFile);
+
+			TestDataUtil.DeleteTestFile(writeToFile);
+
+			Assert.True(actualResult.SequenceEqual(expectedResult));
+		}
 	}
 }

--- a/JpegXmpWritePluginMDE/MetadataExtractor/Formats/Jpeg/JpegMetadataWriter.cs
+++ b/JpegXmpWritePluginMDE/MetadataExtractor/Formats/Jpeg/JpegMetadataWriter.cs
@@ -57,7 +57,8 @@ namespace JpegXmpWritePluginMDE.MetadataExtractor.Formats.Jpeg
 		/// <returns>A new stream that contains Jpeg data, updated with the metadata.</returns>
 		public static void WriteMetadata([NotNull] Stream stream, [NotNull] IEnumerable<object> metadata)
 		{
-			using (BinaryWriter binaryWriter = new BinaryWriter(stream))
+			// Leave the input stream open here in case the caller still needs to use it
+			using (BinaryWriter binaryWriter = new BinaryWriter(stream, System.Text.Encoding.UTF8, leaveOpen: true))
 			{
 				var ssr = new SequentialStreamReader(stream, isMotorolaByteOrder: true);
 				// 1. split up the original data into a collection of fragments (non-coding and coding)

--- a/JpegXmpWritePluginMDE/MetadataExtractor/ImageMetadataWriter.cs
+++ b/JpegXmpWritePluginMDE/MetadataExtractor/ImageMetadataWriter.cs
@@ -56,7 +56,7 @@ namespace JpegXmpWritePluginMDE.MetadataExtractor
 	public static class ImageMetadataWriter
 	{
 		/// <summary>Writes metadata to a <see cref="Stream"/>.</summary>
-		/// <param name="stream">A stream to which the file data may be written.  The stream must be positioned at the beginning of the file's data.</param>
+		/// <param name="filePath">The path to the file to write.</param>
 		/// <param name="metadata">Collection of metadata objects.</param>
 		/// <exception cref="ImageProcessingException">The file type is unknown, or processing errors occurred.</exception>
 		/// <exception cref="IOException"/>
@@ -65,46 +65,62 @@ namespace JpegXmpWritePluginMDE.MetadataExtractor
 		{
 			using (var stream = new FileStream(filePath, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite))
 			{
-				var fileType = FileTypeDetector.DetectFileType(stream);
-				try
-				{
-					switch (fileType)
-					{
-						case FileType.Jpeg:
-							JpegMetadataWriter.WriteMetadata(stream, metadata);
-							break;
-							//case FileType.Tiff:
-							//case FileType.Arw:
-							//case FileType.Cr2:
-							//case FileType.Nef:
-							//case FileType.Orf:
-							//case FileType.Rw2:
-							//    return TiffMetadataReader.ReadMetadata(stream);
-							//case FileType.Psd:
-							//    return PsdMetadataReader.ReadMetadata(stream);
-							//case FileType.Png:
-							//    return PngMetadataReader.ReadMetadata(stream);
-							//case FileType.Bmp:
-							//    return new[] { BmpMetadataReader.ReadMetadata(stream) };
-							//case FileType.Gif:
-							//    return new[] { GifMetadataReader.ReadMetadata(stream) };
-							//case FileType.Ico:
-							//    return IcoMetadataReader.ReadMetadata(stream);
-							//case FileType.Pcx:
-							//    return new[] { PcxMetadataReader.ReadMetadata(stream) };
-							//case FileType.Riff:
-							//    return WebPMetadataReader.ReadMetadata(stream);
-							//case FileType.Raf:
-							//    return RafMetadataReader.ReadMetadata(stream);
-							//case FileType.QuickTime:
-							//    return QuicktimeMetadataReader.ReadMetadata(stream);
-					}
-				}
-				catch (Exception)
-				{
+				WriteMetadata(stream, metadata);
+			}
+		}
 
-					throw new ImageProcessingException("File format is not supported");
+		/// <summary>Writes metadata to a <see cref="Stream"/>.</summary>
+		/// <param name="stream">A stream to which the file data may be written.  The stream must be positioned at the beginning of the file's data.</param>
+		/// <param name="metadata">Collection of metadata objects.</param>
+		/// <exception cref="ImageProcessingException">The file type is unknown, or processing errors occurred.</exception>
+		/// <exception cref="IOException"/>
+		[NotNull]
+		public static void WriteMetadata([NotNull] Stream stream, IEnumerable<object> metadata)
+		{
+			if (!stream.CanWrite)
+			{
+				throw new ImageProcessingException("Input stream must be writeable");
+			}
+
+			var fileType = FileTypeDetector.DetectFileType(stream);
+			try
+			{
+				switch (fileType)
+				{
+					case FileType.Jpeg:
+						JpegMetadataWriter.WriteMetadata(stream, metadata);
+						break;
+						//case FileType.Tiff:
+						//case FileType.Arw:
+						//case FileType.Cr2:
+						//case FileType.Nef:
+						//case FileType.Orf:
+						//case FileType.Rw2:
+						//    return TiffMetadataReader.ReadMetadata(stream);
+						//case FileType.Psd:
+						//    return PsdMetadataReader.ReadMetadata(stream);
+						//case FileType.Png:
+						//    return PngMetadataReader.ReadMetadata(stream);
+						//case FileType.Bmp:
+						//    return new[] { BmpMetadataReader.ReadMetadata(stream) };
+						//case FileType.Gif:
+						//    return new[] { GifMetadataReader.ReadMetadata(stream) };
+						//case FileType.Ico:
+						//    return IcoMetadataReader.ReadMetadata(stream);
+						//case FileType.Pcx:
+						//    return new[] { PcxMetadataReader.ReadMetadata(stream) };
+						//case FileType.Riff:
+						//    return WebPMetadataReader.ReadMetadata(stream);
+						//case FileType.Raf:
+						//    return RafMetadataReader.ReadMetadata(stream);
+						//case FileType.QuickTime:
+						//    return QuicktimeMetadataReader.ReadMetadata(stream);
 				}
+			}
+			catch (Exception)
+			{
+
+				throw new ImageProcessingException("File format is not supported");
 			}
 		}
 	}


### PR DESCRIPTION
We have developed a need to write into files that might not be available as a filepath, only a stream in memory, so - start adding support for that.

(Hasn't had extensive testing yet, just the new unit test)