### PR TITLE
Remove JetBrains.Annotations and rely purely on the built in nullabil…

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,7 +11,6 @@
   </ItemGroup>
   <!-- Centrally defined package versions -->
   <ItemGroup>
-    <PackageVersion Include="JetBrains.Annotations" Version="2023.3.0" />
     <PackageVersion Include="MetadataExtractor" Version="2.9.2" />
     <PackageVersion Include="xunit.assert" Version="2.7.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />

--- a/JpegXmpWritePluginMDE/JpegXmpWritePluginMDE.csproj
+++ b/JpegXmpWritePluginMDE/JpegXmpWritePluginMDE.csproj
@@ -19,7 +19,6 @@
 	</ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" PrivateAssets="All"/>
     <PackageReference Include="MetadataExtractor" PrivateAssets="All"/>
   </ItemGroup>
 

--- a/JpegXmpWritePluginMDE/MetadataExtractor/Formats/Jpeg/IJpegFragmentMetadataWriter.cs
+++ b/JpegXmpWritePluginMDE/MetadataExtractor/Formats/Jpeg/IJpegFragmentMetadataWriter.cs
@@ -24,9 +24,6 @@
 
 using System;
 using System.Collections.Generic;
-using JetBrains.Annotations;
-
-
 
 #if NET35
 using FragmentList = System.Collections.Generic.IList<MetadataExtractor.Formats.Jpeg.JpegFragment>;
@@ -40,7 +37,6 @@ namespace JpegXmpWritePluginMDE.MetadataExtractor.Formats.Jpeg
 	public interface IJpegFragmentMetadataWriter
 	{
 		/// <summary>The IXmpMeta type of metadata that this writer can process.</summary>
-		[NotNull]
 		Type MetadataXmpMetaType { get; }
 
 		/// <summary>Modifies the JpegFragment collection with the metadata update.</summary>
@@ -50,7 +46,6 @@ namespace JpegXmpWritePluginMDE.MetadataExtractor.Formats.Jpeg
 		/// <param name="metadata">
 		/// A directory containing metadata that shall be written to the JpegFragments.
 		/// </param>
-		[NotNull]
-		List<JpegFragment> UpdateFragments([NotNull] FragmentList fragments, [NotNull] object metadata);
+		List<JpegFragment> UpdateFragments(FragmentList fragments, object metadata);
 	}
 }

--- a/JpegXmpWritePluginMDE/MetadataExtractor/Formats/Jpeg/JpegFragmentWriter.cs
+++ b/JpegXmpWritePluginMDE/MetadataExtractor/Formats/Jpeg/JpegFragmentWriter.cs
@@ -25,9 +25,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
-using System.Linq;
-using JetBrains.Annotations;
 using MetadataExtractor.Formats.Jpeg;
 using MetadataExtractor.IO;
 
@@ -51,8 +48,7 @@ namespace JpegXmpWritePluginMDE.MetadataExtractor.Formats.Jpeg
 		/// It must be positioned at the beginning of the JPEG data stream.
 		/// </param>
 		/// <returns>A list of all fragments that, when concatenated, match the input stream.</returns>
-		[NotNull]
-		public static List<JpegFragment> SplitFragments([NotNull] SequentialReader reader)
+		public static List<JpegFragment> SplitFragments(SequentialReader reader)
 		{
 			if (!reader.IsMotorolaByteOrder)
 				throw new JpegProcessingException("Must be big-endian/Motorola byte order.");
@@ -147,8 +143,7 @@ namespace JpegXmpWritePluginMDE.MetadataExtractor.Formats.Jpeg
 		/// Concatenates the provided JpegFragments into a <see cref="byte[]"/>.
 		/// </summary>
 		/// <param name="fragments">a list of JpegFragments that shall be joined.</param>
-		[NotNull]
-		public static byte[] JoinFragments([NotNull] IEnumerable<JpegFragment> fragments)
+		public static byte[] JoinFragments(IEnumerable<JpegFragment> fragments)
 		{
 			using (MemoryStream output = new MemoryStream())
 			{
@@ -166,7 +161,7 @@ namespace JpegXmpWritePluginMDE.MetadataExtractor.Formats.Jpeg
 		/// </summary>
 		/// <param name="fragments">Ordered list of JpegFragments</param>
 		/// <returns>true if passed</returns>
-		public static bool IsValid([NotNull] IEnumerable<JpegFragment> fragments)
+		public static bool IsValid(IEnumerable<JpegFragment> fragments)
 		{
 			throw new NotImplementedException();
 		}

--- a/JpegXmpWritePluginMDE/MetadataExtractor/Formats/Jpeg/JpegMetadataWriter.cs
+++ b/JpegXmpWritePluginMDE/MetadataExtractor/Formats/Jpeg/JpegMetadataWriter.cs
@@ -22,7 +22,6 @@
 //
 #endregion
 
-using JetBrains.Annotations;
 using JpegXmpWritePluginMDE.MetadataExtractor.Formats.Xmp;
 
 #if !PORTABLE
@@ -55,7 +54,7 @@ namespace JpegXmpWritePluginMDE.MetadataExtractor.Formats.Jpeg
 		/// <param name="original">Stream of the original file.</param>
 		/// <param name="metadata">Collection of metadata objects.</param>
 		/// <returns>A new stream that contains Jpeg data, updated with the metadata.</returns>
-		public static void WriteMetadata([NotNull] Stream stream, [NotNull] IEnumerable<object> metadata)
+		public static void WriteMetadata(Stream stream, IEnumerable<object> metadata)
 		{
 			// Leave the input stream open here in case the caller still needs to use it
 			using (BinaryWriter binaryWriter = new BinaryWriter(stream, System.Text.Encoding.UTF8, leaveOpen: true))
@@ -89,7 +88,7 @@ namespace JpegXmpWritePluginMDE.MetadataExtractor.Formats.Jpeg
 		/// <param name="metadata">Collection of metadata items.</param>
 		/// <param name="writers">A dictionary that maps metadata types to compatible JpegMetadataWriters.</param>
 		/// <returns>The updated list of JpegFragments</returns>
-		public static List<JpegFragment> UpdateJpegFragments([NotNull] List<JpegFragment> fragments, [NotNull] IEnumerable<object> metadata, [NotNull] Dictionary<Type, IJpegFragmentMetadataWriter>? writers = null)
+		public static List<JpegFragment> UpdateJpegFragments(List<JpegFragment> fragments, IEnumerable<object> metadata, Dictionary<Type, IJpegFragmentMetadataWriter>? writers = null)
 		{
 			if (writers == null)
 				writers = _allWriters;

--- a/JpegXmpWritePluginMDE/MetadataExtractor/Formats/Jpeg/JpegSegmentPlugin.cs
+++ b/JpegXmpWritePluginMDE/MetadataExtractor/Formats/Jpeg/JpegSegmentPlugin.cs
@@ -22,10 +22,7 @@
 //
 #endregion
 
-using JetBrains.Annotations;
 using MetadataExtractor.Formats.Jpeg;
-using System;
-using System.Runtime.CompilerServices;
 
 namespace JpegXmpWritePluginMDE.MetadataExtractor.Formats.Jpeg
 {
@@ -37,10 +34,10 @@ namespace JpegXmpWritePluginMDE.MetadataExtractor.Formats.Jpeg
 	public sealed class JpegSegmentPlugin
 	{
 		public JpegSegmentType Type { get; }
-		[NotNull] public byte[] Bytes { get; }
+		public byte[] Bytes { get; }
 		public long Offset { get; }
 
-		public JpegSegmentPlugin(JpegSegmentType type, [NotNull] byte[] bytes, long offset)
+		public JpegSegmentPlugin(JpegSegmentType type, byte[] bytes, long offset)
 		{
 			Type = type;
 			Bytes = bytes;

--- a/JpegXmpWritePluginMDE/MetadataExtractor/Formats/Xmp/XmpWriter.cs
+++ b/JpegXmpWritePluginMDE/MetadataExtractor/Formats/Xmp/XmpWriter.cs
@@ -1,10 +1,7 @@
-﻿using JetBrains.Annotations;
-using JpegXmpWritePluginMDE.MetadataExtractor.Formats.Jpeg;
+﻿using JpegXmpWritePluginMDE.MetadataExtractor.Formats.Jpeg;
 using MetadataExtractor.Formats.Jpeg;
 using MetadataExtractor.Formats.Xmp;
 using System.Text;
-using System.Xml;
-using System.Xml.Linq;
 using XmpCore;
 using XmpCore.Impl;
 using XmpCore.Options;
@@ -34,7 +31,7 @@ namespace JpegXmpWritePluginMDE.MetadataExtractor.Formats.Xmp
 		/// <param name="fragments">Original file fragmets</param>
 		/// <param name="metadata">The Xmp metadata that shall be written</param>
 		/// <returns>A new list of JpegFragments</returns>
-		public List<JpegFragment> UpdateFragments([NotNull] FragmentList fragments, [NotNull] object metadata)
+		public List<JpegFragment> UpdateFragments(FragmentList fragments, object metadata)
 		{
 			JpegFragment metadataFragment;
 			List<JpegFragment> output = new List<JpegFragment>();
@@ -102,7 +99,7 @@ namespace JpegXmpWritePluginMDE.MetadataExtractor.Formats.Xmp
 		/// </summary>
 		/// <param name="xmpMeta">Xmp document to be encoded</param>
 		/// <returns>App1 segment payload</returns>
-		public static byte[] WritePreambleToXmpBytes([NotNull] IXmpMeta xmpMeta)
+		public static byte[] WritePreambleToXmpBytes(IXmpMeta xmpMeta)
 		{
 			// xmp preamble
 			byte[] preamble = XmpReader.JpegSegmentPreamble.ToArray();

--- a/JpegXmpWritePluginMDE/MetadataExtractor/ImageMetadataWriter.cs
+++ b/JpegXmpWritePluginMDE/MetadataExtractor/ImageMetadataWriter.cs
@@ -22,7 +22,6 @@
 //
 #endregion
 
-using JetBrains.Annotations;
 using JpegXmpWritePluginMDE.MetadataExtractor.Formats.Jpeg;
 using MetadataExtractor;
 
@@ -60,8 +59,7 @@ namespace JpegXmpWritePluginMDE.MetadataExtractor
 		/// <param name="metadata">Collection of metadata objects.</param>
 		/// <exception cref="ImageProcessingException">The file type is unknown, or processing errors occurred.</exception>
 		/// <exception cref="IOException"/>
-		[NotNull]
-		public static void WriteMetadata([NotNull] string filePath, IEnumerable<object> metadata)
+		public static void WriteMetadata(string filePath, IEnumerable<object> metadata)
 		{
 			using (var stream = new FileStream(filePath, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite))
 			{
@@ -74,8 +72,7 @@ namespace JpegXmpWritePluginMDE.MetadataExtractor
 		/// <param name="metadata">Collection of metadata objects.</param>
 		/// <exception cref="ImageProcessingException">The file type is unknown, or processing errors occurred.</exception>
 		/// <exception cref="IOException"/>
-		[NotNull]
-		public static void WriteMetadata([NotNull] Stream stream, IEnumerable<object> metadata)
+		public static void WriteMetadata(Stream stream, IEnumerable<object> metadata)
 		{
 			if (!stream.CanWrite)
 			{


### PR DESCRIPTION
…ity annotations.

The project already has the built in nullability annotations enabled, and the core MetadataExtractor project has already dropped the JetBrains annotations in favour of that, so any thoughts or objections to dropping it to remove a dependency?